### PR TITLE
Fix Assembly Definition in Editor folder

### DIFF
--- a/src/Blockfrost.io/Editor/Blockfrost.Editor.asmdef
+++ b/src/Blockfrost.io/Editor/Blockfrost.Editor.asmdef
@@ -4,7 +4,9 @@
     "references": [
         "GUID:be4fcdd22dd41994392923b08dd8863f"
     ],
-    "includePlatforms": [],
+    "includePlatforms":  [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/src/Blockfrost.io/Scripts/Configuration.cs
+++ b/src/Blockfrost.io/Scripts/Configuration.cs
@@ -45,7 +45,8 @@ namespace Blockfrost {
         private int _currentNetworkIndex;
         public int CurrentNetworkIndex { get => _currentNetworkIndex; protected set => _currentNetworkIndex = value; }
 
-        public Server CurrentServer { get => servers[CurrentApi][CurrentNetworkIndex]; }
+        public List<Server> CurrentApiServers { get => servers[CurrentApi]; }
+        public Server CurrentServer { get => CurrentApiServers[CurrentNetworkIndex]; }
 
         [SerializeField]
         [HideInInspector]
@@ -88,7 +89,7 @@ namespace Blockfrost {
         }
 
         public void ChangeNetwork(int index) {
-            if (index >= servers.Count) {
+            if (index >= CurrentApiServers.Count) {
                 Debug.LogError($"Invalid network index {index}");
                 return;
             }

--- a/src/Blockfrost.io/Scripts/Configuration.cs
+++ b/src/Blockfrost.io/Scripts/Configuration.cs
@@ -59,6 +59,14 @@ namespace Blockfrost {
                     Network = "Testnet",
                     Url = "cardano-testnet.blockfrost.io/api/v0",
                 },
+                new Server{
+                    Network = "Preprod",
+                    Url = "cardano-preprod.blockfrost.io/api/v0",
+                },
+                new Server{
+                    Network = "Preview",
+                    Url = "cardano-preview.blockfrost.io/api/v0",
+                },
             }}, {
             MilkomedaApi, new List<Server>{
                 new Server{


### PR DESCRIPTION
Editor folder creates a compilation error on build due to not being excluded from all platforms, except "Editor"

Corrects build error :
"The type or namespace name 'Editor' could not be found (are you missing a using directive or an assembly reference?"